### PR TITLE
Replace the curly braces with square brackets

### DIFF
--- a/sansorchi.php
+++ b/sansorchi.php
@@ -99,7 +99,7 @@ class BinaryStream
           //  throw new Exception\UnderflowException('Buffer underrun at needle position: ' . $this->_needle . ' while requesting length: 1');
         }
 
-        return ord($this->_stream{$this->_needle++});
+        return ord($this->_stream[$this->_needle++]);
     }
 
     /**


### PR DESCRIPTION
this code is using curly braces to access string offsets, which is no longer supported in php